### PR TITLE
经过各种排查,在init_log之前去除掉根root上的StreamHandler,可以排除掉双倍log

### DIFF
--- a/huoutil/util.py
+++ b/huoutil/util.py
@@ -313,6 +313,10 @@ def init_log(log_path,
     if not os.path.isdir(dir):
         os.makedirs(dir)
 
+    for handler in logger.handlers:
+        if isinstance(handler, logging.StreamHandler):
+            logger.removeHandler(handler)
+
     if stdout:
         stdout_handler = logging.StreamHandler(sys.stdout)
         stdout_handler.setLevel(level)


### PR DESCRIPTION
已试验